### PR TITLE
Correct copy-and-paste mistake

### DIFF
--- a/unpack/Makemodule.am
+++ b/unpack/Makemodule.am
@@ -19,7 +19,7 @@ if WITH_LZ4
 rdsquashfs_LDADD += $(LZ4_LIBS)
 endif
 
-if WITH_LZ4
+if WITH_ZSTD
 rdsquashfs_LDADD += $(ZSTD_LIBS)
 endif
 


### PR DESCRIPTION
Would cause the build to fail if zstd was enable and lz4 was disabled.

Signed-off-by: Matt Turner <mattst88@gmail.com>