### PR TITLE
Enable largefile support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_RANLIB
 AC_PROG_INSTALL
+AC_SYS_LARGEFILE
 
 m4_ifndef([PKG_PROG_PKG_CONFIG],
   [m4_fatal([Could not locate the pkg-config autoconf

--- a/include/compress.h
+++ b/include/compress.h
@@ -2,6 +2,8 @@
 #ifndef COMPRESS_H
 #define COMPRESS_H
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/include/data_reader.h
+++ b/include/data_reader.h
@@ -2,6 +2,8 @@
 #ifndef DATA_READER_H
 #define DATA_READER_H
 
+#include "config.h"
+
 #include "frag_reader.h"
 #include "squashfs.h"
 #include "compress.h"

--- a/include/data_writer.h
+++ b/include/data_writer.h
@@ -2,6 +2,8 @@
 #ifndef DATA_WRITER_H
 #define DATA_WRITER_H
 
+#include "config.h"
+
 #include "squashfs.h"
 #include "compress.h"
 #include "fstree.h"

--- a/include/frag_reader.h
+++ b/include/frag_reader.h
@@ -2,6 +2,8 @@
 #ifndef FRAG_READER_H
 #define FRAG_READER_H
 
+#include "config.h"
+
 #include "squashfs.h"
 #include "compress.h"
 

--- a/include/fstree.h
+++ b/include/fstree.h
@@ -2,6 +2,8 @@
 #ifndef FSTREE_H
 #define FSTREE_H
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdbool.h>

--- a/include/highlevel.h
+++ b/include/highlevel.h
@@ -2,6 +2,8 @@
 #ifndef HIGHLEVEL_H
 #define HIGHLEVEL_H
 
+#include "config.h"
+
 #include "squashfs.h"
 #include "compress.h"
 #include "id_table.h"

--- a/include/id_table.h
+++ b/include/id_table.h
@@ -2,6 +2,8 @@
 #ifndef ID_TABLE_H
 #define ID_TABLE_H
 
+#include "config.h"
+
 #include <stdint.h>
 #include <stddef.h>
 

--- a/include/meta_reader.h
+++ b/include/meta_reader.h
@@ -2,6 +2,8 @@
 #ifndef META_READER_H
 #define META_READER_H
 
+#include "config.h"
+
 #include "compress.h"
 #include "squashfs.h"
 

--- a/include/meta_writer.h
+++ b/include/meta_writer.h
@@ -2,6 +2,8 @@
 #ifndef META_WRITER_H
 #define META_WRITER_H
 
+#include "config.h"
+
 #include "compress.h"
 #include "squashfs.h"
 #include "id_table.h"

--- a/include/squashfs.h
+++ b/include/squashfs.h
@@ -2,6 +2,8 @@
 #ifndef SQUASHFS_H
 #define SQUASHFS_H
 
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>

--- a/include/tar.h
+++ b/include/tar.h
@@ -2,6 +2,8 @@
 #ifndef TAR_H
 #define TAR_H
 
+#include "config.h"
+
 #include <sys/stat.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/include/util.h
+++ b/include/util.h
@@ -2,6 +2,8 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <stdint.h>
 

--- a/lib/comp/compressor.c
+++ b/lib/comp/compressor.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/comp/gzip.c
+++ b/lib/comp/gzip.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/comp/internal.h
+++ b/lib/comp/internal.h
@@ -2,6 +2,8 @@
 #ifndef INTERNAL_H
 #define INTERNAL_H
 
+#include "config.h"
+
 #include "compress.h"
 
 int generic_write_options(int fd, const void *data, size_t size);

--- a/lib/comp/lz4.c
+++ b/lib/comp/lz4.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/comp/lzo.c
+++ b/lib/comp/lzo.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/comp/xz.c
+++ b/lib/comp/xz.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/comp/zstd.c
+++ b/lib/comp/zstd.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/fstree/add_by_path.c
+++ b/lib/fstree/add_by_path.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/fstree.c
+++ b/lib/fstree/fstree.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/fstree_from_dir.c
+++ b/lib/fstree/fstree_from_dir.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 #include "util.h"
 

--- a/lib/fstree/fstree_from_file.c
+++ b/lib/fstree/fstree_from_file.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 #include "util.h"
 

--- a/lib/fstree/fstree_sort.c
+++ b/lib/fstree/fstree_sort.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/gen_inode_table.c
+++ b/lib/fstree/gen_inode_table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/lib/fstree/get_path.c
+++ b/lib/fstree/get_path.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/mknode.c
+++ b/lib/fstree/mknode.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/node_from_path.c
+++ b/lib/fstree/node_from_path.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/node_stat.c
+++ b/lib/fstree/node_stat.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <string.h>

--- a/lib/fstree/selinux.c
+++ b/lib/fstree/selinux.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <selinux/selinux.h>

--- a/lib/fstree/xattr.c
+++ b/lib/fstree/xattr.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/lib/sqfs/data_reader.c
+++ b/lib/sqfs/data_reader.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "data_reader.h"
 #include "frag_reader.h"
 #include "util.h"

--- a/lib/sqfs/data_writer.c
+++ b/lib/sqfs/data_writer.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "data_writer.h"
 #include "highlevel.h"
 #include "util.h"

--- a/lib/sqfs/deserialize_fstree.c
+++ b/lib/sqfs/deserialize_fstree.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 #include "highlevel.h"
 

--- a/lib/sqfs/frag_reader.c
+++ b/lib/sqfs/frag_reader.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 #include "frag_reader.h"
 #include "util.h"

--- a/lib/sqfs/id_table.c
+++ b/lib/sqfs/id_table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "id_table.h"
 
 #include <stdlib.h>

--- a/lib/sqfs/id_table_read.c
+++ b/lib/sqfs/id_table_read.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 #include "highlevel.h"
 #include "util.h"

--- a/lib/sqfs/id_table_write.c
+++ b/lib/sqfs/id_table_write.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "highlevel.h"
 
 int id_table_write(id_table_t *tbl, int outfd, sqfs_super_t *super,

--- a/lib/sqfs/meta_reader.c
+++ b/lib/sqfs/meta_reader.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 #include "util.h"
 

--- a/lib/sqfs/meta_writer.c
+++ b/lib/sqfs/meta_writer.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_writer.h"
 #include "squashfs.h"
 #include "util.h"

--- a/lib/sqfs/read_inode.c
+++ b/lib/sqfs/read_inode.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 
 #include <sys/stat.h>

--- a/lib/sqfs/read_super.c
+++ b/lib/sqfs/read_super.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "squashfs.h"
 #include "util.h"
 

--- a/lib/sqfs/readdir.c
+++ b/lib/sqfs/readdir.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 
 #include <stdlib.h>

--- a/lib/sqfs/serialize_fstree.c
+++ b/lib/sqfs/serialize_fstree.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_writer.h"
 #include "highlevel.h"
 #include "util.h"

--- a/lib/sqfs/super.c
+++ b/lib/sqfs/super.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "squashfs.h"
 #include "util.h"
 

--- a/lib/sqfs/table.c
+++ b/lib/sqfs/table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_writer.h"
 #include "highlevel.h"
 #include "util.h"

--- a/lib/sqfs/tree_node_from_inode.c
+++ b/lib/sqfs/tree_node_from_inode.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "highlevel.h"
 
 #include <stdlib.h>

--- a/lib/sqfs/write_dir.c
+++ b/lib/sqfs/write_dir.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_writer.h"
 #include "util.h"
 

--- a/lib/sqfs/write_export_table.c
+++ b/lib/sqfs/write_export_table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "highlevel.h"
 
 #include <stdlib.h>

--- a/lib/sqfs/write_inode.c
+++ b/lib/sqfs/write_inode.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_writer.h"
 #include "util.h"
 

--- a/lib/sqfs/write_xattr.c
+++ b/lib/sqfs/write_xattr.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_writer.h"
 #include "highlevel.h"
 #include "util.h"

--- a/lib/tar/base64.c
+++ b/lib/tar/base64.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 static uint8_t convert(char in)

--- a/lib/tar/checksum.c
+++ b/lib/tar/checksum.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 void update_checksum(tar_header_t *hdr)

--- a/lib/tar/cleanup.c
+++ b/lib/tar/cleanup.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 void free_sparse_list(sparse_map_t *sparse)

--- a/lib/tar/internal.h
+++ b/lib/tar/internal.h
@@ -2,6 +2,8 @@
 #ifndef INTERNAL_H
 #define INTERNAL_H
 
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/lib/tar/number.c
+++ b/lib/tar/number.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 int read_octal(const char *str, int digits, uint64_t *out)

--- a/lib/tar/read_header.c
+++ b/lib/tar/read_header.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 static bool is_zero_block(const tar_header_t *hdr)

--- a/lib/tar/read_sparse_map.c
+++ b/lib/tar/read_sparse_map.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 sparse_map_t *read_sparse_map(const char *line)

--- a/lib/tar/read_sparse_map_old.c
+++ b/lib/tar/read_sparse_map_old.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 sparse_map_t *read_gnu_old_sparse(int fd, tar_header_t *hdr)

--- a/lib/tar/skip.c
+++ b/lib/tar/skip.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/lib/tar/urldecode.c
+++ b/lib/tar/urldecode.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 static int xdigit(int x)

--- a/lib/tar/write_header.c
+++ b/lib/tar/write_header.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "internal.h"
 
 static void write_binary(char *dst, uint64_t value, int digits)

--- a/lib/util/canonicalize_name.c
+++ b/lib/util/canonicalize_name.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 
 static void normalize_slashes(char *filename)

--- a/lib/util/dirstack.c
+++ b/lib/util/dirstack.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>

--- a/lib/util/mkdir_p.c
+++ b/lib/util/mkdir_p.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>

--- a/lib/util/padd_file.c
+++ b/lib/util/padd_file.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 
 #include <stdlib.h>

--- a/lib/util/print_version.c
+++ b/lib/util/print_version.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "config.h"
+
 #include "util.h"
 
 #include <stdio.h>

--- a/lib/util/read_data.c
+++ b/lib/util/read_data.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <unistd.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/util/str_table.c
+++ b/lib/util/str_table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/util/write_data.c
+++ b/lib/util/write_data.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <unistd.h>
 #include <errno.h>
 #include <stdio.h>

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "mkfs.h"
 
 static int process_file(data_writer_t *data, tree_node_t *n, bool quiet)

--- a/mkfs/mkfs.h
+++ b/mkfs/mkfs.h
@@ -2,6 +2,8 @@
 #ifndef MKFS_H
 #define MKFS_H
 
+#include "config.h"
+
 #include "meta_writer.h"
 #include "data_writer.h"
 #include "highlevel.h"
@@ -9,7 +11,6 @@
 #include "compress.h"
 #include "id_table.h"
 #include "fstree.h"
-#include "config.h"
 #include "util.h"
 
 #include <getopt.h>

--- a/mkfs/options.c
+++ b/mkfs/options.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "mkfs.h"
 
 static struct option long_opts[] = {

--- a/tar/sqfs2tar.c
+++ b/tar/sqfs2tar.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "meta_reader.h"
 #include "data_reader.h"
 #include "highlevel.h"

--- a/tar/tar2sqfs.c
+++ b/tar/tar2sqfs.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "data_writer.h"
 #include "highlevel.h"
 #include "squashfs.h"

--- a/tests/add_by_path.c
+++ b/tests/add_by_path.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/canonicalize_name.c
+++ b/tests/canonicalize_name.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 
 #include <string.h>

--- a/tests/fstree_from_file.c
+++ b/tests/fstree_from_file.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <sys/sysmacros.h>

--- a/tests/fstree_init.c
+++ b/tests/fstree_init.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/fstree_sort.c
+++ b/tests/fstree_sort.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/fstree_xattr.c
+++ b/tests/fstree_xattr.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/gen_inode_table.c
+++ b/tests/gen_inode_table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/get_path.c
+++ b/tests/get_path.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/mknode_dir.c
+++ b/tests/mknode_dir.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/mknode_reg.c
+++ b/tests/mknode_reg.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/mknode_simple.c
+++ b/tests/mknode_simple.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/mknode_slink.c
+++ b/tests/mknode_slink.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "fstree.h"
 
 #include <stdlib.h>

--- a/tests/str_table.c
+++ b/tests/str_table.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include <stdlib.h>
 #include <assert.h>
 #include <unistd.h>

--- a/tests/tar_gnu.c
+++ b/tests/tar_gnu.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_pax.c
+++ b/tests/tar_pax.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_sparse_gnu.c
+++ b/tests/tar_sparse_gnu.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_sparse_gnu1.c
+++ b/tests/tar_sparse_gnu1.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_sparse_gnu2.c
+++ b/tests/tar_sparse_gnu2.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_ustar.c
+++ b/tests/tar_ustar.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_xattr_bsd.c
+++ b/tests/tar_xattr_bsd.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/tests/tar_xattr_schily.c
+++ b/tests/tar_xattr_schily.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "util.h"
 #include "tar.h"
 

--- a/unpack/describe.c
+++ b/unpack/describe.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "rdsquashfs.h"
 
 #include <sys/sysmacros.h>

--- a/unpack/list_files.c
+++ b/unpack/list_files.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "rdsquashfs.h"
 
 #include <sys/sysmacros.h>

--- a/unpack/options.c
+++ b/unpack/options.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "rdsquashfs.h"
 
 static struct option long_opts[] = {

--- a/unpack/rdsquashfs.c
+++ b/unpack/rdsquashfs.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "rdsquashfs.h"
 
 int main(int argc, char **argv)

--- a/unpack/rdsquashfs.h
+++ b/unpack/rdsquashfs.h
@@ -2,6 +2,8 @@
 #ifndef RDSQUASHFS_H
 #define RDSQUASHFS_H
 
+#include "config.h"
+
 #include "meta_reader.h"
 #include "data_reader.h"
 #include "highlevel.h"
@@ -9,7 +11,6 @@
 #include "compress.h"
 #include "id_table.h"
 #include "fstree.h"
-#include "config.h"
 #include "util.h"
 
 #include <string.h>

--- a/unpack/restore_fstree.c
+++ b/unpack/restore_fstree.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "config.h"
+
 #include "rdsquashfs.h"
 
 static int create_node(tree_node_t *n, data_reader_t *data, int flags)


### PR DESCRIPTION
Requires that config.h be included before other headers, since the macro
_FILE_OFFSET_BITS changes the definitions of things like 'struct stat'.
I chose to simply include it at the top of every C file and at
immediately after the double-inclusion guards of every header.

Signed-off-by: Matt Turner <mattst88@gmail.com>