### PR TITLE
Increment pointer

### DIFF
--- a/lib/util/canonicalize_name.c
+++ b/lib/util/canonicalize_name.c
@@ -38,8 +38,10 @@ int canonicalize_name(char *filename)
 
 	while (*src != '\0') {
 		if (src[0] == '.') {
-			if (src[1] == '\0')
+			if (src[1] == '\0') {
+				dst++;
 				break;
+			}
 			if (src[1] == '/') {
 				src += 2;
 				continue;


### PR DESCRIPTION
Without incrementing `dst`, the pointer would be pointing at the second last character and it would turn filenames such as ./ into empty string later by`*dst = 0;` I'm assuming **.** filenames are valid as they do exist in tar archives.