### PR TITLE
Fix build on BSD systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,8 @@ AC_INIT([squashfs-tools-ng], [0.7], [goliath@infraroot.at], squashfs-tools-ng)
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign dist-xz subdir-objects])
 AM_SILENT_RULES([yes])
+AC_PROG_CC([cc gcc clang])
 LT_INIT([win32-dll])
-AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_INSTALL
 AC_SYS_LARGEFILE

--- a/include/util/compat.h
+++ b/include/util/compat.h
@@ -7,6 +7,10 @@
 #ifndef COMPAT_H
 #define COMPAT_H
 
+#ifndef __linux__
+#define O_PATH 0
+#endif
+
 #if defined(__APPLE__)
 #include <libkern/OSByteOrder.h>
 
@@ -17,14 +21,8 @@
 #define le32toh(x) OSSwapLittleToHostInt32(x)
 #define le16toh(x) OSSwapLittleToHostInt16(x)
 #define le64toh(x) OSSwapLittleToHostInt64(x)
-#elif defined(__OpenBSD__)
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
-#include <sys/endian.h>
-
-#define le16toh(x) letoh16(x)
-#define le32toh(x) letoh32(x)
-#define le64toh(x) letoh64(x)
 #elif defined(_WIN32) || defined(__WINDOWS__)
 #define htole16(x) (x)
 #define htole32(x) (x)
@@ -107,7 +105,6 @@ struct stat {
 #else
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/sysmacros.h>
 #endif
 
 #ifndef HAVE_GETLINE

--- a/lib/common/dirstack.c
+++ b/lib/common/dirstack.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2019 David Oberhollenzer <goliath@infraroot.at>
  */
 #include "common.h"
+#include "util/compat.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/lib/common/mkdir_p.c
+++ b/lib/common/mkdir_p.c
@@ -7,7 +7,7 @@
 #include "common.h"
 
 #include <string.h>
-#include <alloca.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
 


### PR DESCRIPTION
I tested FreeBSD, DragonflyBSD, NetBSD and OpenBSD and the endian
macros weren't necessary (and in fact caused errors) on all of them.

Because OpenBSD ships with an ancient GCC that doesn't support the
checked addition/multiplication builtins, the build there would fail
unless built with CC=cc or CC=clang.  I changed configure.ac to prefer
cc over gcc, so that the distribution's compiler preference is
respected.  (The default is [gcc cc]).  I had to move AC_PROG_CC above
LT_INIT because otherwise LT_INIT would run AC_PROG_CC first, and we
wouldn't have a chance to use non-default parameters.