### PR TITLE
Include sys/sysmacros.h on any GNU libc platform

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -150,7 +150,7 @@ int chdir(const char *path);
 #include <unistd.h>
 #include <fcntl.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__GLIBC__)
 #include <sys/sysmacros.h>
 #endif
 #endif


### PR DESCRIPTION
`sys/sysmacros.h` is an implementation of GNU libc, so include it unconditionally when that libc is used.