### PR TITLE
Fix missing header without LZO

### DIFF
--- a/lib/common/compress.c
+++ b/lib/common/compress.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2019 David Oberhollenzer <goliath@infraroot.at>
  */
 #include "common.h"
+#include <assert.h>
 
 static int cmp_ids[] = {
 	SQFS_COMP_XZ,


### PR DESCRIPTION
```
lib/common/compress.c: In function 'compressor_get_default':
lib/common/compress.c:39:2: warning: implicit declaration of function 'assert' [-Wimplicit-function-declaration]
   39 |  assert(0);
      |  ^~~~~~
lib/common/compress.c:8:1: note: 'assert' is defined in header '<assert.h>'; did you forget to '#include <assert.h>'?
    7 | #include "common.h"
  +++ |+#include <assert.h>
    8 |
```