### PR TITLE
Enable uint128_t path

### DIFF
--- a/lib/util/fast_urem_by_const.h
+++ b/lib/util/fast_urem_by_const.h
@@ -48,7 +48,7 @@
 static inline uint32_t
 _mul32by64_hi(uint32_t a, uint64_t b)
 {
-#ifdef HAVE_UINT128
+#if __SIZEOF_INT128__ == 16
    return ((__uint128_t) b * a) >> 64;
 #else
    /*


### PR DESCRIPTION
I forgot to enable this when I copied it over from Mesa. Mesa's
meson configuration system checks that a C program using the uint128_t
type compiles, but I think this is likely unnecessary. Simply check the
macro that clang and gcc define.

This cuts the .text size of hash_table.o by 160 bytes or about 4% on my
system.

Signed-off-by: Matt Turner <mattst88@gmail.com>