### PR TITLE
Docker build

### DIFF
--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -1,0 +1,71 @@
+# Dockerfile fo build a package for following Linux distributions:
+#
+#
+#  * alpine
+#  * archlinux
+#  * centos
+#  * fedora
+#  * debian
+#  * ubuntu
+#  * opensuse
+#
+
+ARG vendor
+ARG release
+ARG version=1.0.2
+
+FROM $vendor:$release
+# Args are not globaly scoped
+ARG vendor
+ARG release
+ARG version=1.0.2
+
+# Install tools required to build a package for several distributions.
+#
+# Create a user and add it to sudoers.
+RUN case $vendor in \
+	alpine) \
+		apk add alpine-sdk sudo ;\
+		;; \
+	archlinux) \
+		pacman -Sy; \
+		pacman -S --noconfirm fakeroot binutils namcap sudo ;\
+		;; \
+	centos|fedora) \
+		yum install -y rpm-build spectool sudo ;\
+		;; \
+	debian|ubuntu) \
+		apt-get update ;\
+		DEBIAN_FRONTEND=noninteractive apt-get install -y \
+			-o Dpkg::Options::=--force-confdef \
+			-o APT::Install-Recommends=no \
+			build-essential \
+			ca-certificates \
+			devscripts \
+			equivs \
+			libdistro-info-perl \
+			sudo \
+			wget \
+			;\
+		;; \
+	opensuse|opensuse/leap) \
+		zypper install -y rpm-build sudo wget ;\
+		;; \
+	*) \
+		echo "Unsupported vendor '$vendor' (version: '$version')"; \
+		exit 1; \
+		;; \
+	esac; \
+	case $vendor in \
+		alpine) adduser -G abuild -s /bin/ash -D builder ;; \
+		*) useradd -m -s /bin/sh builder ;; \
+	esac; \
+	echo 'builder ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/builder; \
+	chmod 0400 /etc/sudoers.d/builder
+
+USER builder
+WORKDIR /home/builder
+
+ENV vendor=$vendor
+ENV release=$release
+ENV version=$version

--- a/packages/PKGBUILD
+++ b/packages/PKGBUILD
@@ -19,6 +19,7 @@ makedepends=(
     'automake'
     'autogen'
     'libtool'
+    'pkgconf'
     'm4'
     'make'
     'gcc'

--- a/packages/README.md
+++ b/packages/README.md
@@ -3,7 +3,23 @@
 This directory contains files to build packages for several Linux
 distributions.
 
-# APK
+## Build using Docker images
+
+Packages for a specific release can be built using Docker. Use the
+`build` script for that:
+
+```
+./build VENDOR RELEASE
+```
+
+If you want to build all supported vendors and releases, you can use
+the `build_all` script.
+
+Packages will be output in `_out` directory.
+
+## Manual build
+
+### APK
 
 [APKBUILD]() containts all definition to build APK packages for Alpine
 linux.
@@ -26,7 +42,7 @@ abuild-keygen -nai
 abuild -r
 ```
 
-# DEB
+### DEB
 
 The [debian]() directory contains all definitions to build Debian and
 Ubuntu packages.
@@ -52,7 +68,7 @@ debuild -- clean
 ```
 
 
-# PKG
+### PKG
 
 [PKGBUILD]() contains all definition to build Archlinux packages.
 
@@ -69,12 +85,12 @@ You can check the packages using `namcap`:
 namcap -i squashfs-tools-*.pkg.tar.zst  PKGBUILD
 ```
 
-# RPM
+### RPM
 
 [squashfs-tools-ng.spec]() contains all definitions to build RPM
 packages.
 
-## CentOS, Fedora
+#### CentOS, Fedora
 
 Run following commands:
 
@@ -86,7 +102,7 @@ rpmspec --parse squashfs-tools-ng.spec | grep BuildRequires | cut -d' ' -f2  | x
 rpmbuild --clean -ba squashfs-tools-ng.spec
 ```
 
-## OpenSUSE
+### OpenSUSE
 
 Run following commands:
 

--- a/packages/build
+++ b/packages/build
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Build a package for a specific distribution using a Docker image.
+#
+# ./build DISTRO RELEASE 
+#
+# From a given DISTRO:RELEASE it create a new local Docker image named
+# DISTRO-builder:RELEASE and installs tools required to build a
+# package (it does not install package build depends).
+#
+# It also creates a builder user to prevent from building packages as
+# root.
+#
+# Once the image is setup, it starts a docker image and run
+# build-helper to build the packages. The packages files are stored in
+# _OUT/DISTRO/RELEASE.
+#
+
+
+vendor="$1"
+release="$2"
+
+if test -z "$vendor" -o -z "$release"; then
+    cat<<EOF >&2
+$0 VENDOR RELEASE
+EOF
+    exit 1
+fi
+
+source_dir=$(git rev-parse --show-toplevel)
+output_dir=$source_dir/_out
+empty_dir=$output__dir/_empty
+
+if test "$vendor" = "opensuse"; then
+    vendor=opensuse/leap
+    pkg_dir=$output_dir/$vendor-$release
+else
+    pkg_dir=$output_dir/$vendor/$release
+fi
+
+image=$vendor-builder:$release
+
+mkdir -p $pkg_dir
+mkdir -p $output_dir/_empty
+
+# Build docker image
+docker build -t $image -f packages/Dockerfile \
+       --build-arg vendor="$vendor" \
+       --build-arg release="$release" \
+       .
+
+docker_args="-v $source_dir:/source-ro:ro -v $empty_dir:/source-ro/_out:ro"
+docker_args="$docker_args -v $pkg_dir:/output:rw"
+docker_args="$docker_args -v $source_dir/packages/build-helper:/build-helper"
+docker_args="$docker_args --rm"
+
+docker run -it $docker_args $image /build-helper

--- a/packages/build-all
+++ b/packages/build-all
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+vendors='alpine archlinux centos debian fedora opensuse ubuntu'
+
+alpine_versions='3.11 3.12'
+archlinux_versions='latest'
+centos_versions='7 8'
+debian_versions='bookworm bullseye buster strech'
+fedora_versions='32'
+opensuse_versions='15.0 15.1 15.2'
+ubuntu_versions='bionic focal groovy'
+
+source_dir=$(git rev-parse --show-toplevel)
+
+
+for v in $vendors; do
+    versions="${v}_versions"
+    for ver in ${!versions}; do
+	$source_dir/packages/build $v $ver
+    done
+done
+	 

--- a/packages/build-helper
+++ b/packages/build-helper
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+# This script builds squashfs-tools-ng packages inside a Docker
+# instance.
+#
+# It can build packages for:
+#
+#  * alpine
+#  * archlinux
+#  * centos
+#  * fedora
+#  * debian
+#  * ubuntu
+#  * opensuse
+#
+# Currently it can only build package from a release (tag from github).
+#
+# TODO: Find a way to build packages from git checkout sources
+
+# Path to the source directory mounted in the Docker instance.
+ROOT_RO=/source-ro
+
+# Path to which packages will be copied after a successful build.
+OUTPUT=/output
+
+. /etc/os-release
+
+build_alpine() {
+    cp -r $ROOT_RO/packages/APKBUILD .
+
+    abuild-keygen -nai
+    abuild -r
+
+    cp ~/packages/*/x86_64/*.apk $OUTPUT
+}
+
+
+
+build_archlinux() {
+    cp -r $ROOT_RO/packages/PKGBUILD .
+    makepkg --noconfirm -Cfsir PKGBUILD
+
+    cp ~/*.tar.zst $OUTPUT
+}
+
+
+# This part is a ugly hack.
+# TODO: Find a better way to build deb packages.
+build_deb() {
+    # Fetch sources
+    wget \
+	https://github.com/AgentD/squashfs-tools-ng/archive/v$version/squashfs-tools-ng-$version.tar.gz \
+	-O squashfs-tools-ng_$version+$VERSION_CODENAME.orig.tar.gz
+
+    tar xfz squashfs-tools-ng_$version+$VERSION_CODENAME.orig.tar.gz
+    cd squashfs-tools-ng-$version
+    cp -r $ROOT_RO/packages/debian .
+
+    #ln -s packages/debian
+    DEBFULLNAME="$USER" DEBEMAIL="$USER@localhost" \
+	       dch -v $version+$VERSION_CODENAME-1 \
+	       -D $VERSION_CODENAME "Build $version for $VERSION_CODENAME."
+
+    # See https://packages.debian.org/search?searchon=sourcenames&keywords=debhelper
+    # https://packages.ubuntu.com/search?keywords=debhelper&searchon=names&suite=all&section=all
+    case "$VERSION_CODENAME" in
+	jessie|xenial) dhv=9 ;;
+	stretch) dhv=10 ;;
+	bionic) dhv=11 ;;
+	buster|focal) dhv=12 ;;
+	bookworm|bullseye|groovy) dhv=13 ;;
+	sid) dhv=13 ;;
+    esac
+
+    sed -i -e "s/@DEBHELPER_VERSION@/$dhv/" debian/control
+    echo $dhv > debian/compat
+
+    sudo mk-build-deps --install \
+	 --tool='apt-get --no-install-recommends --yes' debian/control
+    sudo rm -f *-build-deps_*
+    
+    debuild
+    debuild -- clean
+    
+    cat /tmp/squashfs-tools-ng*
+    cp ../*.deb $OUTPUT
+}
+
+
+build_rpm() {
+    case "$ID" in
+	centos)
+	    if test $VERSION_ID -ge 8; then
+		# install doxygen
+		sudo sed -i 's/^enabled=.*/enabled=1/' \
+		     /etc/yum.repos.d/CentOS-PowerTools.repo
+		cat /etc/yum.repos.d/CentOS-PowerTools.repo
+	    fi
+	    ;;
+    esac
+
+    cp -r $ROOT_RO/packages/squashfs-tools-ng.spec .
+    rpmdev-setuptree
+    spectool -g -R squashfs-tools-ng.spec
+    rpmspec --parse squashfs-tools-ng.spec \
+	| grep BuildRequires | cut -d' ' -f2  \
+	| xargs sudo yum install -y
+    rpmbuild --clean -ba squashfs-tools-ng.spec
+    cp ~/rpmbuild/RPMS/x86_64/*.rpm $OUTPUT
+
+}
+
+
+build_opensuse() {
+    cp -r $ROOT_RO/packages/squashfs-tools-ng.spec .
+
+    # Fetch source
+    rpmspec --parse squashfs-tools-ng.spec | grep Source0 \
+	| awk '{print $2}' \
+	| xargs  wget -N -P $(rpm --eval '%{_sourcedir}')
+
+    # Install build requirements
+    rpmspec --parse squashfs-tools-ng.spec | grep BuildRequires \
+	| cut -d' ' -f2  \
+	| xargs sudo zypper install -y
+    
+    rpmbuild --clean -ba squashfs-tools-ng.spec
+    cp ~/rpmbuild/RPMS/x86_64/*.rpm $OUTPUT
+}
+
+
+
+
+
+
+
+case "$ID" in
+    alpine) build_alpine ;;
+    archlinux|arch) build_archlinux ;;
+    centos|fedora) build_rpm;;
+    debian|ubuntu) build_deb;;
+    opensuse|opensuse-leap) build_opensuse;;
+    *) cat <<EOF >&2
+Unsupported distro "$ID"
+EOF
+       exit 1
+       ;;
+esac

--- a/packages/squashfs-tools-ng.spec
+++ b/packages/squashfs-tools-ng.spec
@@ -1,7 +1,7 @@
 ## Spec file to build squashf-tools-ng RPM package.
 
 # OpenSUSE has no dist macro
-%if 0%{suse_version} > 0
+%if 0%{?suse_version} > 0
 %global dist .sles%{suse_version}
 %endif
 
@@ -37,7 +37,7 @@ this package from the original:
    SELinux labels.
 
 
-%if 0%{?el} > 7 || 0%{?fedora} >= 32 || 0%{?suse_version} >= 1500
+%if 0%{?centos} > 7 || 0%{?fedora} >= 32 || 0%{?suse_version} >= 1500
 %global use_zstd 1
 %endif
 
@@ -49,6 +49,7 @@ BuildRequires: automake
 BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: doxygen
+BuildRequires: libselinux-devel
 BuildRequires: zlib-devel
 BuildRequires: xz-devel
 BuildRequires: lzo-devel
@@ -74,6 +75,7 @@ Requires: xz
 Requires: lzo
 Requires: libattr
 Requires: lz4
+Requires: libselinux
 
 #Recommends: squashfs-tools
    


### PR DESCRIPTION
Docker image can now be used to build packages for following distributions:

* alpine
* archlinux
* centos
* fedora
* debian
* ubuntu
* opensuse
