### PR TITLE
Fix more normalization of slashes in filenames.

### DIFF
--- a/lib/sqfs/dir_reader.c
+++ b/lib/sqfs/dir_reader.c
@@ -277,8 +277,8 @@ int sqfs_dir_reader_find_by_path(sqfs_dir_reader_t *rd,
 		return ret;
 
 	while (*path != '\0') {
-		if (*path == '/' || *path == '\\') {
-			while (*path == '/' || *path == '\\')
+		if (*path == '/') {
+			while (*path == '/')
 				++path;
 			continue;
 		}
@@ -290,7 +290,6 @@ int sqfs_dir_reader_find_by_path(sqfs_dir_reader_t *rd,
 
 		ptr = strchr(path, '/');
 		if (ptr == NULL) {
-			ptr = strchr(path, '\\');
 
 			if (ptr == NULL) {
 				for (ptr = path; *ptr != '\0'; ++ptr)

--- a/lib/sqfs/read_tree.c
+++ b/lib/sqfs/read_tree.c
@@ -214,8 +214,8 @@ int sqfs_dir_reader_get_full_hierarchy(sqfs_dir_reader_t *rd,
 	inode = NULL;
 
 	while (path != NULL && *path != '\0') {
-		if (*path == '/' || *path == '\\') {
-			while (*path == '/' || *path == '\\')
+		if (*path == '/') {
+			while (*path == '/')
 				++path;
 			continue;
 		}
@@ -226,7 +226,6 @@ int sqfs_dir_reader_get_full_hierarchy(sqfs_dir_reader_t *rd,
 
 		ptr = strchr(path, '/');
 		if (ptr == NULL) {
-			ptr = strchr(path, '\\');
 
 			if (ptr == NULL) {
 				for (ptr = path; *ptr != '\0'; ++ptr)


### PR DESCRIPTION
It looks like the last commit missed a couple more occurences
where backslash was treated incorrectly.

Fixes were still needed in sqfs_dir_reader_find_by_path and
sqfs_dir_reader_get_full_hierarchy.

This path is used in extras/browse.c.

It'd be good to get this into the fixes/1.0.0 branch as well.
If requested, I'll make a separate PR for that after this one lands.