### PR TITLE
Only use available CPUs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,10 +287,9 @@ AS_IF([test "x$have_compressor" != "xyes"],
 
 ##### additional checks #####
 AC_CHECK_HEADERS([sys/xattr.h], [], [])
-AC_CHECK_HEADERS([sys/sysinfo.h], [], [])
 AC_CHECK_HEADERS([alloca.h], [], [])
 
-AC_CHECK_FUNCS([strndup getopt getopt_long getsubopt fnmatch strchrnul])
+AC_CHECK_FUNCS([strndup getopt getopt_long getsubopt fnmatch strchrnul sched_getaffinity])
 
 ##### generate output #####
 

--- a/lib/common/writer/init.c
+++ b/lib/common/writer/init.c
@@ -10,16 +10,20 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
-#ifdef HAVE_SYS_SYSINFO_H
-#include <sys/sysinfo.h>
+#ifdef HAVE_SCHED_GETAFFINITY
+#include <sched.h>
 
 static size_t os_get_num_jobs(void)
 {
-	int nprocs;
+	cpu_set_t cpu_set;
+	CPU_ZERO(&cpu_set);
 
-	nprocs = get_nprocs_conf();
-	return nprocs < 1 ? 1 : nprocs;
+	if (sched_getaffinity(0, sizeof cpu_set, &cpu_set) == -1)
+		return 1;
+	else
+		return CPU_COUNT(&cpu_set);
 }
 #else
 static size_t os_get_num_jobs(void)


### PR DESCRIPTION
Not all CPUs may be available for the current process. Some CPUs may be offline, others may not be included in the process affinity mask. In such cases too many threads will be created, which will then compete unnecessarily for CPU time.

Use sched_getaffinity() to determine the correct number of threads to create.