### PR TITLE
tar2sqfs: Add option to exclude files

### DIFF
--- a/bin/tar2sqfs/src/tar2sqfs.c
+++ b/bin/tar2sqfs/src/tar2sqfs.c
@@ -8,9 +8,10 @@
 
 int main(int argc, char **argv)
 {
-	int status = EXIT_FAILURE;
 	sqfs_istream_t *input_file = NULL;
+	tar_iterator_opts topts = { 0 };
 	dir_iterator_t *tar = NULL;
+	int status = EXIT_FAILURE;
 	sqfs_writer_t sqfs;
 	int ret;
 
@@ -22,7 +23,10 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	tar = tar_open_stream(input_file);
+	topts.excludedirs = excludedirs;
+	topts.num_excludedirs = num_excludedirs;
+
+	tar = tar_open_stream(input_file, &topts);
 	sqfs_drop(input_file);
 	if (tar == NULL) {
 		fputs("Creating tar stream: out-of-memory\n", stderr);

--- a/bin/tar2sqfs/src/tar2sqfs.h
+++ b/bin/tar2sqfs/src/tar2sqfs.h
@@ -29,6 +29,8 @@ extern bool no_tail_pack;
 extern bool no_symlink_retarget;
 extern sqfs_writer_cfg_t cfg;
 extern char *root_becomes;
+extern char **excludedirs;
+extern size_t num_excludedirs;
 
 void process_args(int argc, char **argv);
 

--- a/include/tar/tar.h
+++ b/include/tar/tar.h
@@ -39,6 +39,11 @@ typedef struct {
 	sqfs_s64 mtime;
 } tar_header_decoded_t;
 
+typedef struct {
+	char **excludedirs;
+	size_t num_excludedirs;
+} tar_iterator_opts;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,7 +68,7 @@ int read_header(sqfs_istream_t *fp, tar_header_decoded_t *out);
 
 void clear_header(tar_header_decoded_t *hdr);
 
-dir_iterator_t *tar_open_stream(sqfs_istream_t *stream);
+dir_iterator_t *tar_open_stream(sqfs_istream_t *stream, tar_iterator_opts *opts);
 
 /*
   Write zero bytes to an output file to padd it to the tar record size.

--- a/lib/tar/test/tar_iterator.c
+++ b/lib/tar/test/tar_iterator.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 	TEST_EQUAL_I(iret, 0);
 	TEST_NOT_NULL(fp);
 	TEST_EQUAL_UI(((sqfs_object_t *)fp)->refcount, 1);
-	it = tar_open_stream(fp);
+	it = tar_open_stream(fp, NULL);
 	TEST_NOT_NULL(it);
 	TEST_EQUAL_UI(((sqfs_object_t *)fp)->refcount, 2);
 	TEST_EQUAL_UI(((sqfs_object_t *)it)->refcount, 1);
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 				      0);
 	TEST_EQUAL_I(iret, 0);
 	TEST_NOT_NULL(fp);
-	it = tar_open_stream(fp);
+	it = tar_open_stream(fp, NULL);
 	TEST_NOT_NULL(it);
 
 	/* read entry */

--- a/lib/tar/test/tar_iterator2.c
+++ b/lib/tar/test/tar_iterator2.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 				      0);
 	TEST_EQUAL_I(iret, 0);
 	TEST_NOT_NULL(fp);
-	it = tar_open_stream(fp);
+	it = tar_open_stream(fp, NULL);
 	TEST_NOT_NULL(it);
 	sqfs_drop(fp);
 

--- a/lib/tar/test/tar_iterator3.c
+++ b/lib/tar/test/tar_iterator3.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 	TEST_EQUAL_I(ret, 0);
 	TEST_NOT_NULL(fp);
 	TEST_EQUAL_UI(((sqfs_object_t *)fp)->refcount, 1);
-	it = tar_open_stream(fp);
+	it = tar_open_stream(fp, NULL);
 	TEST_NOT_NULL(it);
 	TEST_EQUAL_UI(((sqfs_object_t *)fp)->refcount, 2);
 	TEST_EQUAL_UI(((sqfs_object_t *)it)->refcount, 1);


### PR DESCRIPTION
Using --exclude or -E it is now possible to exclude files from the input tar stream.
The options can be used multiple times.